### PR TITLE
Reuse ProtocolLib objects in BoneMetaPacket

### DIFF
--- a/src/main/java/com/mcmiddleearth/entities/protocol/packets/composite/BoneInitPacket.java
+++ b/src/main/java/com/mcmiddleearth/entities/protocol/packets/composite/BoneInitPacket.java
@@ -1,55 +1,52 @@
 package com.mcmiddleearth.entities.protocol.packets.composite;
 
+import com.comphenix.protocol.events.PacketContainer;
 import com.comphenix.protocol.wrappers.WrappedDataWatcher;
 import com.mcmiddleearth.entities.entities.composite.bones.Bone;
 import org.bukkit.entity.Player;
 
 public class BoneInitPacket extends BoneMetaPacket {
 
-    WrappedDataWatcher watcher = new WrappedDataWatcher();
-
     public BoneInitPacket(Bone bone) {
         super(bone,0);
 
 //long start = System.currentTimeMillis();
-        writeInit(watcher);
-//Logger.getGlobal().info("Init: "+(System.currentTimeMillis()-start));
-
-        writeHeadPose(watcher);
-//Logger.getGlobal().info("Pose: "+(System.currentTimeMillis()-start));
 
         writeHeadItem();
 //Logger.getGlobal().info("item: "+(System.currentTimeMillis()-start));
 
-        posePacket.getWatchableCollectionModifier().write(0,watcher.getWatchableObjects());
 //Logger.getGlobal().info("Bone creation: "+(System.currentTimeMillis()-start));
+    }
+
+    @Override
+    protected PacketContainer createHeadPosePacket(WrappedDataWatcher dataWatcher) {
+        PacketContainer packet = super.createHeadPosePacket(dataWatcher);
+
+        WrappedDataWatcher.WrappedDataWatcherObject invisibility = new WrappedDataWatcher
+                .WrappedDataWatcherObject(0,WrappedDataWatcher.Registry.get(Byte.class));
+        dataWatcher.setObject(invisibility, Byte.decode("0x20"),false);
+        WrappedDataWatcher.WrappedDataWatcherObject silent = new WrappedDataWatcher
+                .WrappedDataWatcherObject(4,WrappedDataWatcher.Registry.get(Boolean.class));
+        dataWatcher.setObject(silent, true,false);
+        WrappedDataWatcher.WrappedDataWatcherObject gravity = new WrappedDataWatcher
+                .WrappedDataWatcherObject(5,WrappedDataWatcher.Registry.get(Boolean.class));
+        dataWatcher.setObject(gravity, false,false);
+        WrappedDataWatcher.WrappedDataWatcherObject base = new WrappedDataWatcher
+                .WrappedDataWatcherObject(14,WrappedDataWatcher.Registry.get(Byte.class));
+        dataWatcher.setObject(base, Byte.decode("0x08"),false);
+
+        return packet;
     }
 
     @Override
     public void update() {
         if(bone.isHasHeadPoseUpdate()) {
-            writeHeadPose(watcher);
-            posePacket.getWatchableCollectionModifier().write(0,watcher.getWatchableObjects());
+            updateHeadPose(getHeadPose());
         }
 
         if(bone.isHasItemUpdate()) {
             writeHeadItem();
         }
-    }
-
-    protected void writeInit(WrappedDataWatcher watcher) {
-        WrappedDataWatcher.WrappedDataWatcherObject invisibility = new WrappedDataWatcher
-                .WrappedDataWatcherObject(0,WrappedDataWatcher.Registry.get(Byte.class));
-        watcher.setObject(invisibility, Byte.decode("0x20"),false);
-        WrappedDataWatcher.WrappedDataWatcherObject silent = new WrappedDataWatcher
-                .WrappedDataWatcherObject(4,WrappedDataWatcher.Registry.get(Boolean.class));
-        watcher.setObject(silent, true,false);
-        WrappedDataWatcher.WrappedDataWatcherObject gravity = new WrappedDataWatcher
-                .WrappedDataWatcherObject(5,WrappedDataWatcher.Registry.get(Boolean.class));
-        watcher.setObject(gravity, false,false);
-        WrappedDataWatcher.WrappedDataWatcherObject base = new WrappedDataWatcher
-                .WrappedDataWatcherObject(14,WrappedDataWatcher.Registry.get(Byte.class));
-        watcher.setObject(base, Byte.decode("0x08"),false);
     }
 
     @Override

--- a/src/main/java/com/mcmiddleearth/entities/protocol/packets/composite/BoneMetaPacket.java
+++ b/src/main/java/com/mcmiddleearth/entities/protocol/packets/composite/BoneMetaPacket.java
@@ -23,12 +23,14 @@ public class BoneMetaPacket extends AbstractPacket {
 
     private boolean hasPoseUpdate, hasItemUpdate;
 
-    private final List<WrappedDataWatcher> headPoseQueue = new ArrayList<>();
+    private final WrappedDataWatcher headPoseDataWatcher = new WrappedDataWatcher();
+    private final WrappedDataWatcher.WrappedDataWatcherObject headPoseWrappedObject = new WrappedDataWatcher.WrappedDataWatcherObject(15, WrappedDataWatcher.Registry.getVectorSerializer());
+    private final List<Vector3F> headPoseQueue = new ArrayList<>();
 
     public BoneMetaPacket(Bone bone, int headPoseDelay) {
         this.bone = bone;
-        posePacket = new PacketContainer(PacketType.Play.Server.ENTITY_METADATA);
-        posePacket.getIntegers().write(0,bone.getEntityId());
+        posePacket = createHeadPosePacket(headPoseDataWatcher);
+        posePacket.getWatchableCollectionModifier().write(0, headPoseDataWatcher.getWatchableObjects());
 
         equipPacket = new PacketContainer(PacketType.Play.Server.ENTITY_EQUIPMENT);
         equipPacket.getIntegers().write(0,bone.getEntityId());
@@ -40,22 +42,24 @@ public class BoneMetaPacket extends AbstractPacket {
         update();
     }
 
+    protected PacketContainer createHeadPosePacket(WrappedDataWatcher dataWatcher) {
+        PacketContainer posePacket = new PacketContainer(PacketType.Play.Server.ENTITY_METADATA);
+        posePacket.getIntegers().write(0, bone.getEntityId());
+
+        updateHeadPose(getHeadPose());
+
+        return posePacket;
+    }
+
     @Override
     public void update() {
-        if(bone.isHasHeadPoseUpdate()) {
-            WrappedDataWatcher watcher = new WrappedDataWatcher();
-            writeHeadPose(watcher);
-            headPoseQueue.add(watcher);
-        } else {
-            headPoseQueue.add(null);
-        }
-        if(headPoseQueue.get(0)!=null) {
-            posePacket.getWatchableCollectionModifier().write(0,headPoseQueue.get(0).getWatchableObjects());
+        Vector3F nextHeadPose = updateHeadPoseQueueAndPopNext();
+        if(nextHeadPose != null) {
+            headPoseDataWatcher.setObject(headPoseWrappedObject, nextHeadPose, false);
             hasPoseUpdate = true;
         } else {
             hasPoseUpdate = false;
         }
-        headPoseQueue.remove(0);
         if(bone.isHasItemUpdate()) {
             writeHeadItem();
             hasItemUpdate = true;
@@ -64,12 +68,31 @@ public class BoneMetaPacket extends AbstractPacket {
         }
     }
 
-    protected void writeHeadPose(WrappedDataWatcher watcher) {
-        WrappedDataWatcher.WrappedDataWatcherObject state = new WrappedDataWatcher
-                .WrappedDataWatcherObject(15, WrappedDataWatcher.Registry.getVectorSerializer());
-        watcher.setObject(state, new Vector3F((float)bone.getRotatedHeadPose().getX(),
-                                              (float)bone.getRotatedHeadPose().getY(),
-                                              (float)bone.getRotatedHeadPose().getZ()), false);
+    private Vector3F updateHeadPoseQueueAndPopNext() {
+        boolean hasHeadPoseUpdate = bone.isHasHeadPoseUpdate();
+
+        if (headPoseQueue.size() == 0) {
+            // No delay is enabled - skip the queue
+            return hasHeadPoseUpdate ? getHeadPose() : null;
+        }
+
+        if (hasHeadPoseUpdate) {
+            headPoseQueue.add(getHeadPose());
+        } else {
+            headPoseQueue.add(null);
+        }
+
+        return headPoseQueue.remove(0);
+    }
+
+    protected Vector3F getHeadPose() {
+        return new Vector3F((float)bone.getRotatedHeadPose().getX(),
+                (float)bone.getRotatedHeadPose().getY(),
+                (float)bone.getRotatedHeadPose().getZ());
+    }
+
+    protected void updateHeadPose(Vector3F headPose) {
+        headPoseDataWatcher.setObject(headPoseWrappedObject, headPose, false);
     }
 
     protected void writeHeadItem() {


### PR DESCRIPTION
Constantly creating new instances is expensive - it does a lot behind the scenes.